### PR TITLE
ColorTheme

### DIFF
--- a/Source/dlgSynEditOptions.pas
+++ b/Source/dlgSynEditOptions.pas
@@ -217,6 +217,7 @@ type
     FUserCommand: TSynEditorOptionsUserCommand;
     FAllUserCommands: TSynEditorOptionsAllUserCommands;
     FExtended: Boolean;
+    FColorTheme: String;
 
     procedure GetData;
     procedure PutData;
@@ -238,6 +239,7 @@ type
       read FAllUserCommands
       write FAllUserCommands;
     property UseExtendedStrings: Boolean read FExtended write FExtended;
+    property ColorTheme: String read FColorTheme write FColorTheme;
   end;
 
   TSynHighlighterCountEvent = procedure(Sender:TObject; var Count:integer) of object;
@@ -760,6 +762,7 @@ begin
   finally
     KeyList.Items.EndUpdate;
   end;
+  lbColorThemes.ItemIndex:= lbColorThemes.Items.IndexOf(FColorTheme);
 end;
 
 procedure TfmEditorOptionsDialog.PutData;
@@ -957,6 +960,7 @@ begin
     finally
         AppStorage.Free;
     end;
+    FColorTheme:= lbColorThemes.Items[lbColorThemes.ItemIndex];
   end;
 end;
 

--- a/Source/dmCommands.pas
+++ b/Source/dmCommands.pas
@@ -918,11 +918,13 @@ begin
       OnSetHighlighter := SynEditOptionsDialogSetHighlighter;
       VisiblePages := [soDisplay, soOptions, soKeystrokes, soColor];
       TSynEditOptionsDialog.HighlighterFileDir := TPyScripterSettings.ColorThemesFilesDir;
+      Form.ColorTheme := PyIDEMainForm.AppStorage.ReadString('ColorTheme');
       GetUserCommand := GetEditorUserCommand;
       GetAllUserCommands := GetEditorAllUserCommands;
       UseExtendedStrings := True;
       if Execute(TempEditorOptions) then begin
         UpdateHighlighters;
+        PyIDEMainForm.AppStorage.WriteString('ColorTheme', Form.ColorTheme);
         if Form.cbApplyToAll.Checked then begin
           EditorOptions.Assign(TempEditorOptions);
           ApplyEditorOptions;


### PR DESCRIPTION
With this pull request in the editor options window the current color theme is selected in the list of all color themes.
So the user can see, which color theme currently is active. 

It doesn't reflect, that a user can change the colors of a color theme.  If he changes it, then this changed color theme doesn't change it's name. But this is what the user is normally expecting. 
