### PR TITLE
Digits for not AutoSize

### DIFF
--- a/Source/dlgSynEditOptions.dfm
+++ b/Source/dlgSynEditOptions.dfm
@@ -1019,6 +1019,13 @@ inherited fmEditorOptionsDialog: TfmEditorOptionsDialog
             Anchors = [akTop, akRight]
             Caption = 'Gutter color:'
           end
+          object lDigits: TLabel
+            Left = 185
+            Top = 40
+            Width = 33
+            Height = 15
+            Caption = 'Digits:'
+          end
           object pnlGutterFontDisplay: TPanel
             Left = 363
             Top = 44
@@ -1054,10 +1061,11 @@ inherited fmEditorOptionsDialog: TfmEditorOptionsDialog
           object ckGutterAutosize: TCheckBox
             Left = 24
             Top = 38
-            Width = 230
+            Width = 145
             Height = 21
             Caption = 'Autosize'
             TabOrder = 1
+            OnClick = ckGutterAutosizeClick
           end
           object ckGutterShowLineNumbers: TCheckBox
             Left = 24
@@ -1121,6 +1129,14 @@ inherited fmEditorOptionsDialog: TfmEditorOptionsDialog
             Caption = 'Font'
             TabOrder = 5
             OnClick = btnGutterFontClick
+          end
+          object EDigits: TEdit
+            Left = 240
+            Top = 37
+            Width = 42
+            Height = 23
+            TabOrder = 10
+            Text = '2'
           end
         end
         object gbBookmarks: TGroupBox

--- a/Source/dlgSynEditOptions.pas
+++ b/Source/dlgSynEditOptions.pas
@@ -189,6 +189,8 @@ type
     btnCancel: TButton;
     btnHelp: TButton;
     ckShowLigatures: TCheckBox;
+    EDigits: TEdit;
+    lDigits: TLabel;
     procedure SynSyntaxSampleClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure btnFontClick(Sender: TObject);
@@ -210,6 +212,7 @@ type
     procedure KeyListSelectItem(Sender: TObject; Item: TListItem; Selected: Boolean);
     procedure lbColorThemesClick(Sender: TObject);
     procedure btnApplyThemeClick(Sender: TObject);
+    procedure ckGutterAutosizeClick(Sender: TObject);
   private
     FHandleChanges : Boolean;  //Normally true, can prevent unwanted execution of event handlers
 
@@ -708,6 +711,8 @@ begin
   lblGutterFont.Font.Assign(FSynEdit.Gutter.Font);
   lblGutterFont.Caption:= lblGutterFont.Font.Name + ' ' + IntToStr(lblGutterFont.Font.Size) + 'pt';
   ckGutterGradient.Checked := FSynEdit.Gutter.Gradient;
+  EDigits.Text:= IntToStr(FSynEdit.Gutter.DigitCount);
+  EDigits.Enabled:= not ckGutterAutosize.Checked;
   //Right Edge
   eRightEdge.Text:= IntToStr(FSynEdit.RightEdge);
   cbRightEdgeColor.SelectedColor:= FSynEdit.RightEdgeColor;
@@ -768,6 +773,7 @@ end;
 procedure TfmEditorOptionsDialog.PutData;
 var
   vOptions: TSynEditorOptions;
+  Digits: integer;
 
   procedure SetFlag(aOption: TSynEditorOption; aValue: Boolean);
   begin
@@ -788,6 +794,10 @@ begin
   FSynEdit.Gutter.UseFontStyle := cbGutterFont.Checked;
   FSynEdit.Gutter.Font.Assign(lblGutterFont.Font);
   FSynEdit.Gutter.Gradient := ckGutterGradient.Checked;
+  if ckGutterAutosize.Checked then
+    FSynEdit.Gutter.DigitCount:= 2
+  else if TryStrToInt(EDigits.Text, Digits) and (2 <= Digits) and (Digits <= 12) then
+    FSynEdit.Gutter.DigitCount:= Digits;
   //Right Edge
   FSynEdit.RightEdge:= StrToIntDef(eRightEdge.Text, 80);
   FSynEdit.RightEdgeColor:= cbRightEdgeColor.SelectedColor;
@@ -1123,6 +1133,11 @@ procedure TfmEditorOptionsDialog.cKeyCommandKeyUp(Sender: TObject;
   var Key: Word; Shift: TShiftState);
 begin
   if Key = SYNEDIT_RETURN then btnUpdateKey.Click;
+end;
+
+procedure TfmEditorOptionsDialog.ckGutterAutosizeClick(Sender: TObject);
+begin
+  EDigits.Enabled:= not ckGutterAutosize.Checked;
 end;
 
 procedure TfmEditorOptionsDialog.cbHighlightersChange(Sender : TObject);


### PR DESCRIPTION
If I uncheck AutoSize in the dlgSynEditOptions dialog all line numbers greater than 100 are clipped, and direct after changing to AutoSize = false not readable. Therefore AutoSize = false needs a possibility to set the number of digits as an enhancement.

Do you want new po files which contain a translation of Digits?