### PR TITLE
Alt Sets Column Mode

### DIFF
--- a/Source/frmPyIDEMain.dfm
+++ b/Source/frmPyIDEMain.dfm
@@ -30,7 +30,7 @@ object PyIDEMainForm: TPyIDEMainForm
     end
     object SpTBXRightAlignSpacerItem1: TSpTBXRightAlignSpacerItem
       Wrapping = twNone
-      CustomWidth = 0
+      CustomWidth = 210
     end
     object SpTBXSeparatorItem22: TSpTBXSeparatorItem
     end
@@ -111,7 +111,6 @@ object PyIDEMainForm: TPyIDEMainForm
       Top = 6
       FrameDelay = 150
       IndicatorSize = aisSmall
-      IndicatorType = aitRefresh
     end
   end
   object BGPanel: TPanel

--- a/Source/frmPyIDEMain.pas
+++ b/Source/frmPyIDEMain.pas
@@ -1352,6 +1352,7 @@ type
     function GetLocalAppStorage: TJvCustomAppStorage;
     function GetLogger: TJclSimpleLog;
     procedure MRUAddEditor(Editor: IEditor);
+    procedure RemoveEoAltSetsColumnMode;
   public
     ActiveTabControlIndex : integer;
     PythonKeywordHelpRequested : Boolean;
@@ -1586,6 +1587,10 @@ begin
 
   // Activity Indicator
   SetActivityIndicator(False);
+
+  // remove eoAltSetsColumnMode to avoid an exception
+  if FileExists(TPyScripterSettings.OptionsFileName) then
+    RemoveEoAltSetsColumnMode;
 
   // Application Storage
   AppStorage.Encoding := TEncoding.UTF8;
@@ -4920,6 +4925,18 @@ end;
 procedure TPyIDEMainForm.SelectEditor(Sender: TObject);
 begin
     ShowFilePosition((Sender as TTBCustomItem).Hint, -1, -1);
+end;
+
+procedure TPyIDEMainForm.RemoveEoAltSetsColumnMode;
+  // since 5.11 to avoid an exception
+begin
+  var SL:= TStringList.Create;
+  SL.LoadFromFile(TPyScripterSettings.OptionsFileName);
+  var s:= SL.Text;
+  s:= StringReplace(s, 'eoAltSetsColumnMode, ', '', [rfReplaceAll, rfIgnoreCase]);
+  SL.Text:= s;
+  SL.SaveToFile(TPyScripterSettings.OptionsFileName);
+  FreeAndNil(SL);
 end;
 
 { TTSpTBXTabControl }


### PR DESCRIPTION
If you have set the editor option "Alt sets column mode" in PyScripter 4.3.x then you get an exception after an update to a 5.x.x version, because eoAltSetsColumnMode is no longer available.

![grafik](https://github.com/user-attachments/assets/91b28ced-462d-475a-a18d-6ae648b385d9)