### PR TITLE
fix OptionsFileName

### DIFF
--- a/Source/cPyScripterSettings.pas
+++ b/Source/cPyScripterSettings.pas
@@ -1121,30 +1121,37 @@ class constructor TPyScripterSettings.CreateSettings;
 
 var
   PublicPath: string;
+  AppName, AppININame, EXEPath: string;
 begin
-  OptionsFileName := ChangeFileExt(Application.ExeName, '.ini');
+  AppName := 'PyScripter';
+  // uncomment the following if you want the options files to be named after the exe name
+//  AppName := ChangeFileExt(ExtractFileName(Application.ExeName), '');
+  AppININame := AppName + '.ini';
+  EXEPath := ExtractFilePath(Application.ExeName);
+
+  OptionsFileName := TPath.Combine(EXEPath, AppININame);
   IsPortable := FileExists(OptionsFileName);
   if IsPortable then begin
     // Portable version - nothing is stored in other directories
-    UserDataPath :=   ExtractFilePath(Application.ExeName);
+    UserDataPath := EXEPath;
     ColorThemesFilesDir := TPath.Combine(UserDataPath, 'Highlighters');
     StylesFilesDir := TPath.Combine(UserDataPath, 'Styles');
     LspServerPath :=  TPath.Combine(UserDataPath, 'Lib\Lsp');
     UserDebugInspectorsDir :=  TPath.Combine(UserDataPath, 'Variable Inspectors');
   end else begin
-    UserDataPath := TPath.Combine(GetHomePath,  'PyScripter\');
-    OptionsFileName := TPath.Combine(UserDataPath, 'PyScripter.ini');
+    UserDataPath := TPath.Combine(GetHomePath,  AppName+'\');
+    OptionsFileName := TPath.Combine(UserDataPath, AppININame);
     if not ForceDirectories(UserDataPath) then
       StyledMessageDlg(Format(SAccessAppDataDir, [UserDataPath]),
       mtWarning, [mbOK], 0);
-    PublicPath := TPath.Combine(TPath.GetPublicPath, 'PyScripter\');
+    PublicPath := TPath.Combine(TPath.GetPublicPath, AppName+'\');
     ColorThemesFilesDir := TPath.Combine(PublicPath, 'Highlighters');
     StylesFilesDir := TPath.Combine(PublicPath, 'Styles');
     LspServerPath :=  TPath.Combine(PublicPath, 'Lsp');
     UserDebugInspectorsDir :=  TPath.Combine(UserDataPath, 'Variable Inspectors');
     AppDebugInspectorsDir := TPath.Combine(PublicPath, 'Variable Inspectors');
     // First use setup
-    CopyFileIfNeeded(TPath.Combine(PublicPath, 'PyScripter.ini'), OptionsFileName);
+    CopyFileIfNeeded(TPath.Combine(PublicPath, AppININame), OptionsFileName);
   end;
   ForceDirectories(UserDebugInspectorsDir);
 

--- a/Source/frmPyIDEMain.pas
+++ b/Source/frmPyIDEMain.pas
@@ -1519,7 +1519,6 @@ type
 procedure TPyIDEMainForm.FormCreate(Sender: TObject);
 var
   TabHost: TJvDockTabHostForm;
-  LocalOptionsFileName: string;
 begin
   // Shell Images
   FShellImages := TCommonVirtualImageList.Create(Self);
@@ -1559,9 +1558,7 @@ begin
   AppStorage.FileName := TPyScripterSettings.OptionsFileName;
 
   // LocalAppStorage
-  LocalOptionsFileName := ChangeFileExt(TPath.GetFileName(Application.ExeName), '.local.ini');
-  LocalAppStorage.FileName :=
-    TPyScripterSettings.UserDataPath + LocalOptionsFileName;
+  LocalAppStorage.FileName := ChangeFileExt(TPyScripterSettings.OptionsFileName, '.local.ini');
 
   //OutputDebugString(PWideChar(Format('%s ElapsedTime %d ms', ['Before All Forms', StopWatch.ElapsedMilliseconds])));
   // Create and layout IDE windows


### PR DESCRIPTION
Options filenames were not consistent, in some places they are defined by the exe name (exename.ini) and in others it's hardcoded `PyScripter.ini`.
I think it should be `PyScripter.ini` and `PyScripter.local.ini` regardless of the exe name.
In a custom build it can be changed by commenting out a single line.