### PR TITLE
LSP - All Python custom paths are now recognized (i.e. in Find Definition)

### DIFF
--- a/Source/LspUtils.pas
+++ b/Source/LspUtils.pas
@@ -184,18 +184,39 @@ begin
     Result := URIToFilePath(URI);
 end;
 
+{function GetProjectDir: String;
+var
+  FileName: String;
+begin
+  Result := '';
+  if Assigned(GI_ActiveEditor) then begin
+    FileName := GI_ActiveEditor.FileName;
+    Result := TPath.GetDirectoryName(FileName);
+  end;
+end;}
+
 function LSPInitializeParams(const ClientName, ClientVersion: string;
   ClientCapabilities: TJSONObject;
   InitializationOptions: TJSONObject = nil): TJSONObject;
 var
   ClientInfo: TJSONObject;
+  RootUri: String;
 begin
   ClientInfo := TJSONObject.Create;
   ClientInfo.AddPair('name', TJSONString.Create(ClientName));
   ClientInfo.AddPair('version', TJSONString.Create(ClientVersion));
   Result := TJSONObject.Create;
   Result.AddPair('clientInfo', ClientInfo);
-  Result.AddPair('rootUri', TJSONNull.Create);
+
+  //RootUri := GetProjectDir;
+  RootUri := GetEnvironmentVariable('USERPROFILE');
+  if RootUri = '' then
+    Result.AddPair('rootUri', TJSONNull.Create)
+  else begin
+    RootUri := FilePathToURI(RootUri);
+    Result.AddPair('rootUri', TJSONString.Create(RootUri));
+  end;
+
   Result.AddPair('capabilities', ClientCapabilities);
   if Assigned(InitializationOptions) then
     Result.AddPair('initializationOptions', InitializationOptions);

--- a/Source/dmCommands.pas
+++ b/Source/dmCommands.pas
@@ -1617,6 +1617,7 @@ begin
       PyControl.ActiveInterpreter.StringsToSysPath(Paths);
   finally
     Paths.Free;
+    TJedi.CreateServer;
   end;
 end;
 


### PR DESCRIPTION
Paths added to Python Path are not recognized by the Language Server.
This PR solves this issue [by adding extraPaths](https://github.com/pappasam/jedi-language-server?tab=readme-ov-file#workspaceextrapaths)

I couldn't find a `Project Dir` concept in PyScripter. [Setting a Project dir is required by the Jedi LSP in order to recognize custom paths](https://github.com/pappasam/jedi-language-server/blob/main/jedi_language_server/server.py#L212), so I set the HOMEDIR as a placeholder.
I thought maybe to set the active script dir as the Project Dir but then we need to restart the LSP when the active is changed, which is no good. WDYT ?

As we need to feed the LSP only the custom Python Paths and not all the paths, this PR depends on: https://github.com/pyscripter/python4delphi/pull/501