### PR TITLE
LSP - RestartServers when the PythonPath is changed (global or project)

### DIFF
--- a/Source/cLSPClients.pas
+++ b/Source/cLSPClients.pas
@@ -1061,12 +1061,14 @@ begin
 
   FProjectPythonPath := NewPath;
 
-  if (Length(Params.event.removed) > 0) or (Length(Params.event.added) > 0) then
+  if (Length(Params.event.removed) > 0) or (Length(Params.event.added) > 0) then begin
     for var Client in LspClients do
       if Client.Ready and
         Client.FLspClient.IsRequestSupported(lspDidChangeWorkspaceFolders)
       then
         Client.FLspClient.SendNotification(lspDidChangeWorkspaceFolders, Params);
+    RestartServers;
+  end;
 end;
 
 class procedure TPyLspClient.PythonVersionChanged(const Sender: TObject; const

--- a/Source/dmCommands.pas
+++ b/Source/dmCommands.pas
@@ -1682,10 +1682,15 @@ begin
   if not GI_PyControl.PythonLoaded then Exit;
 
   var Paths := TStringList.Create;
+  var PathsCurrent := TStringList.Create;
   try
     GI_PyControl.ActiveInterpreter.SysPathToStrings(Paths);
+    PathsCurrent.Assign(Paths);
     if EditFolderList(Paths, _('Python Path'), 870) then
-      GI_PyControl.ActiveInterpreter.StringsToSysPath(Paths);
+      if not PathsCurrent.Equals(Paths) then begin
+        GI_PyControl.ActiveInterpreter.StringsToSysPath(Paths);
+        TPyLspClient.RestartServers;
+      end;
   finally
     Paths.Free;
   end;


### PR DESCRIPTION
related to https://github.com/pyscripter/pyscripter/pull/1404
When the Extra Python Path is changed restart the LSP server - so the LSP will register the new paths.

in https://github.com/pyscripter/pyscripter/pull/1404#issuecomment-3369242903
You wrote - "If you alter the python path via environment variables or registry editing, these changes will be reflected in the python path that the jedi lsp sees." - 
But in my tests (latest 5.3.1) - Extra Global paths are not recognized by the LSP (even if the LSP Server is restarted), 
I tried both adding the path using the GUI, and also adding to `python_int.py` i.e. `sys.path.append(r'c:\temp\python')` - neither work for the LSP (they do get recognized by the interpreter).

I added in this PR a restart also when the Global Path is changed, but this change is not helpful if the Global Path is not recognized by the LSP. 

As a working workaround, you can take a look at the following approach, which does work (see latest commits to these branches):
https://github.com/talos-gis/pyscripter/tree/feat/lsp_global_path
https://github.com/talos-gis/python4delphi/tree/feat/lsp_global_path